### PR TITLE
doc(README): add python3-tk as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ NetTK was developed and tested on Linux. Theoretically, Unix should work just fi
 2. Make sure you have the latest copy of Python (https://www.python.org/downloads/)
   * Ubuntu: ```> sudo apt-get install python3```
 3. Install the python dependencies
-  * Ubuntu: ```> sudo apt-get install python3-matplotlib python3-scapy```
+  * Ubuntu: ```> sudo apt-get install python3-matplotlib python3-scapy python3-tk```
 
 ## Quick Start
 


### PR DESCRIPTION
This packages is not installed by default and without you get an error like 
ModuleNotFoundError: No module named 'tkinter'